### PR TITLE
githubのCICDのDartSDKVersionをFVMに合わせるように修正

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -14,7 +14,8 @@ jobs:
    - uses: actions/checkout@v3
    - uses: subosito/flutter-action@v2.3.0
      with:
-      flutter-version: '3.10.1'
+      flutter-version: '3.16.9'
+      channel: 'stable'
    - name: Create .env file
      run: echo "USE_DEBUG_MODE=${{ secrets.USE_DEBUG_MODE }}" >> .env
           && echo "PGN_API_BASE_URL=${{ secrets.PGN_API_BASE_URL }}" >> .env


### PR DESCRIPTION
## 概要
githubのCICDに設定しているdartSDKのVersionがあまりにも昔過ぎたので、FVMで設定しているflutterのversionに設定し直しました！

## UI
<img src="https://github.com/shinonome-inc/pg_mobile/assets/85224998/ad58017e-75b5-4d71-b149-c878d8e349dd" width="600">

## 参考

https://github.com/subosito/flutter-action