### PR TITLE
メディア（画像と動画）の選択とプレビュー表示に関する技術調査

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -30,7 +30,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     namespace "com.example.pg_mobile"
-    compileSdkVersion 33
+    compileSdkVersion 34
     ndkVersion flutter.ndkVersion
 
     compileOptions {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -30,7 +30,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     namespace "com.example.pg_mobile"
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdkVersion 33
     ndkVersion flutter.ndkVersion
 
     compileOptions {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
     <application
         android:label="pg_mobile"
         android:name="${applicationName}"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,4 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '12.0'
 platform :ios, '12.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
@@ -67,17 +66,17 @@ post_install do |installer|
     ## dart: PermissionGroup.contacts
     # 'PERMISSION_CONTACTS=1',
 
-    ## dart: PermissionGroup.camera
-    # 'PERMISSION_CAMERA=1',
+    # dart: PermissionGroup.camera
+    'PERMISSION_CAMERA=1',
 
-    ## dart: PermissionGroup.microphone
-    # 'PERMISSION_MICROPHONE=1',
+    # dart: PermissionGroup.microphone
+    'PERMISSION_MICROPHONE=1',
 
     ## dart: PermissionGroup.speech
     # 'PERMISSION_SPEECH_RECOGNIZER=1',
 
-    ## dart: PermissionGroup.photos
-    # 'PERMISSION_PHOTOS=1',
+    # dart: PermissionGroup.photos
+    'PERMISSION_PHOTOS=1',
 
     ## dart: PermissionGroup.photosAddOnly
     # 'PERMISSION_PHOTOS_ADD_ONLY=1',

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -41,5 +41,70 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+
+    # Start of the permission_handler configuration
+    target.build_configurations.each do |config|
+
+    # You can enable the permissions needed here. For example to enable camera
+    # permission, just remove the `#` character in front so it looks like this:
+    #
+    # ## dart: PermissionGroup.camera
+    # 'PERMISSION_CAMERA=1'
+    #
+    #  Preprocessor definitions can be found at: https://github.com/Baseflow/flutter-permission-handler/blob/master/permission_handler_apple/ios/Classes/PermissionHandlerEnums.h
+    config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
+    '$(inherited)',
+
+    ## dart: [PermissionGroup.calendarWriteOnly, PermissionGroup.calendar (iOS 16 and below)]
+    # 'PERMISSION_EVENTS=1',
+
+    ## dart: [PermissionGroup.calendarFullAccess, PermissionGroup.calendar (iOS 17 and above)]
+    # 'PERMISSION_EVENTS_FULL_ACCESS=1',
+
+    ## dart: PermissionGroup.reminders
+    # 'PERMISSION_REMINDERS=1',
+
+    ## dart: PermissionGroup.contacts
+    # 'PERMISSION_CONTACTS=1',
+
+    ## dart: PermissionGroup.camera
+    # 'PERMISSION_CAMERA=1',
+
+    ## dart: PermissionGroup.microphone
+    # 'PERMISSION_MICROPHONE=1',
+
+    ## dart: PermissionGroup.speech
+    # 'PERMISSION_SPEECH_RECOGNIZER=1',
+
+    ## dart: PermissionGroup.photos
+    # 'PERMISSION_PHOTOS=1',
+
+    ## dart: PermissionGroup.photosAddOnly
+    # 'PERMISSION_PHOTOS_ADD_ONLY=1',
+
+    ## dart: [PermissionGroup.location, PermissionGroup.locationAlways, PermissionGroup.locationWhenInUse]
+    'PERMISSION_LOCATION=1',
+
+    ## dart: PermissionGroup.notification
+    # 'PERMISSION_NOTIFICATIONS=1',
+
+    ## dart: PermissionGroup.mediaLibrary
+    # 'PERMISSION_MEDIA_LIBRARY=1',
+
+    ## dart: PermissionGroup.sensors
+    # 'PERMISSION_SENSORS=1',
+
+    ## dart: PermissionGroup.bluetooth
+    # 'PERMISSION_BLUETOOTH=1',
+
+    ## dart: PermissionGroup.appTrackingTransparency
+    # 'PERMISSION_APP_TRACKING_TRANSPARENCY=1',
+
+    ## dart: PermissionGroup.criticalAlerts
+    # 'PERMISSION_CRITICAL_ALERTS=1'
+    ]
+
+    end
+    # End of the permission_handler configuration
   end
 end

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -31,7 +31,7 @@ flutter_ios_podfile_setup
 target 'Runner' do
   use_frameworks!
   use_modular_headers!
-
+  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '10.20.0'
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
   target 'RunnerTests' do
     inherit! :search_paths

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -47,6 +47,12 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+    <key>NSCameraUsageDescription</key>
+    <string>このアプリがカメラにアクセスするのを許可します</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>このアプリがマイクにアクセスをするのを許可します</string>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>このアプリがアルバムにアクセスするのを許可します</string>
     <!-- Deep Links　ここから -->
     <key>FlutterDeepLinkingEnabled</key>
     <true/>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -68,5 +68,9 @@
         </dict>
     </array>
     <!-- Deep Links　ここまで追加 -->
+    <key>NSLocationWhenInUseUsageDescription</key>
+    <string>アプリが位置情報を使用することを許可する必要があります。</string>
+    <key>アプリが常に位置情報を使用することを許可する必要があります。</key>
+    <string>Because</string>
 </dict>
 </plist>

--- a/lib/debug/debug_media_page.dart
+++ b/lib/debug/debug_media_page.dart
@@ -23,10 +23,8 @@ class _DebugMediaPageState extends State<DebugMediaPage> {
 
   VideoPlayerController _videoController = VideoPlayerController.asset('');
 
-  final int maxSelectedMediaCount = 4;
-
-  bool get _isFullSelectedMediaCount => _files.length >= maxSelectedMediaCount;
-  bool get _disableAddMedia => _isFullSelectedMediaCount || _hasSelectVideo;
+  /// 画像は4点まで、動画は1点まで選択可能
+  bool get _disableAddMedia => _files.length >= 4 || _hasSelectVideo;
 
   void _setSelectVideo(bool value) {
     setState(() {

--- a/lib/debug/debug_media_page.dart
+++ b/lib/debug/debug_media_page.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:image_picker/image_picker.dart';
+
+class DebugMediaPage extends StatefulWidget {
+  const DebugMediaPage({Key? key}) : super(key: key);
+
+  @override
+  State<DebugMediaPage> createState() => _DebugMediaPageState();
+}
+
+class _DebugMediaPageState extends State<DebugMediaPage> {
+  bool _isLoading = false;
+  List<XFile?> _files = [];
+
+  final _picker = ImagePicker();
+  final int maxMediaCount = 4;
+
+  void _setLoading(bool value) {
+    setState(() {
+      _isLoading = value;
+    });
+  }
+
+  Future<void> _onPressedGallery() async {
+    if (_isLoading) return;
+    if (_files.length >= maxMediaCount) return;
+    _setLoading(true);
+    final files = await _picker.pickMultipleMedia();
+    if (files.isEmpty) {
+      _setLoading(false);
+      return;
+    }
+    setState(() {
+      _files = files;
+    });
+    _setLoading(false);
+  }
+
+  Future<void> _onPressedCamera() async {
+    if (_isLoading) return;
+    if (_files.length >= maxMediaCount) return;
+    _setLoading(true);
+    final image = await _picker.pickImage(source: ImageSource.camera);
+    if (image == null) {
+      _setLoading(false);
+      return;
+    }
+    setState(() {
+      _files.add(image);
+    });
+    _setLoading(false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Media'),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: EdgeInsets.symmetric(horizontal: 16.w),
+          child: Column(
+            children: [
+              const Spacer(),
+              if (_files.isEmpty) const Text('画像・動画が選択されていません'),
+              const Spacer(),
+              ElevatedButton(
+                onPressed: _onPressedCamera,
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Icon(Icons.camera_alt_outlined),
+                    SizedBox(width: 8.w),
+                    const Text('カメラから画像を追加する'),
+                  ],
+                ),
+              ),
+              SizedBox(height: 16.h),
+              ElevatedButton(
+                onPressed: _onPressedGallery,
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Icon(Icons.image_outlined),
+                    SizedBox(width: 8.w),
+                    const Text('アルバムから画像を追加する'),
+                  ],
+                ),
+              ),
+              SizedBox(height: 32.h),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/debug/debug_media_page.dart
+++ b/lib/debug/debug_media_page.dart
@@ -129,81 +129,86 @@ class _DebugMediaPageState extends State<DebugMediaPage> {
         title: const Text('Media'),
       ),
       body: SafeArea(
-        child: Padding(
-          padding: EdgeInsets.symmetric(horizontal: 16.w),
-          child: Column(
-            children: [
-              const Spacer(),
-              _files.isEmpty
-                  ? const Text('画像・動画が選択されていません')
-                  : SizedBox(
-                      height: 120.h,
-                      child: ListView.builder(
-                        itemCount: _files.length,
-                        scrollDirection: Axis.horizontal,
-                        itemBuilder: (context, index) {
-                          final file = _files[index];
-                          if (file == null) {
-                            return const SizedBox.shrink();
-                          }
-                          return Stack(
-                            alignment: Alignment.topRight,
-                            children: [
-                              Container(
-                                width: 120.h,
-                                color: AppColors.gray2,
-                                child: file.isImage
-                                    ? Image(
-                                        image: FileImage(
-                                          File(file.path),
-                                        ),
-                                        fit: BoxFit.cover,
-                                      )
-                                    : file.isVideo
-                                        ? VideoPlayer(_videoController)
-                                        : const SizedBox.shrink(),
+        child: Column(
+          children: [
+            const Spacer(),
+            _files.isEmpty
+                ? const Text('画像・動画が選択されていません')
+                : SizedBox(
+                    height: 120.h,
+                    child: ListView.builder(
+                      itemCount: _files.length,
+                      scrollDirection: Axis.horizontal,
+                      itemBuilder: (context, index) {
+                        final file = _files[index];
+                        if (file == null) {
+                          return const SizedBox.shrink();
+                        }
+                        return Stack(
+                          alignment: Alignment.topRight,
+                          children: [
+                            Container(
+                              width: 120.h,
+                              height: 120.h,
+                              color: AppColors.gray2,
+                              child: file.isImage
+                                  ? Image(
+                                      image: FileImage(
+                                        File(file.path),
+                                      ),
+                                      fit: BoxFit.cover,
+                                    )
+                                  : file.isVideo
+                                      ? VideoPlayer(_videoController)
+                                      : const SizedBox.shrink(),
+                            ),
+                            IconButton(
+                              onPressed: () => _removeMedia(index),
+                              style: IconButton.styleFrom(
+                                backgroundColor: AppColors.gray1A80,
                               ),
-                              IconButton(
-                                onPressed: () => _removeMedia(index),
-                                style: IconButton.styleFrom(
-                                  backgroundColor: AppColors.gray1A80,
-                                ),
-                                icon: const Icon(Icons.close),
-                              ),
-                            ],
-                          );
-                        },
-                      ),
+                              icon: const Icon(Icons.close),
+                            ),
+                          ],
+                        );
+                      },
                     ),
-              const Spacer(),
-              ElevatedButton(
-                onPressed: _disableAddMedia ? null : _onPressedCamera,
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    const Icon(Icons.camera_alt_outlined),
-                    SizedBox(width: 8.w),
-                    const Text('カメラからメディアを追加する'),
-                  ],
-                ),
+                  ),
+            const Spacer(),
+            Padding(
+              padding: EdgeInsets.all(16.w),
+              child: Column(
+                children: [
+                  ElevatedButton(
+                    onPressed: _disableAddMedia ? null : _onPressedCamera,
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        const Icon(Icons.camera_alt_outlined),
+                        SizedBox(width: 8.w),
+                        const Text('カメラからメディアを追加する'),
+                      ],
+                    ),
+                  ),
+                  SizedBox(height: 16.h),
+                  ElevatedButton(
+                    onPressed: _disableAddMedia ? null : _onPressedGallery,
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        const Icon(Icons.image_outlined),
+                        SizedBox(width: 8.w),
+                        const Text('アルバムからメディアを追加する'),
+                      ],
+                    ),
+                  ),
+                ],
               ),
-              SizedBox(height: 16.h),
-              ElevatedButton(
-                onPressed: _disableAddMedia ? null : _onPressedGallery,
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    const Icon(Icons.image_outlined),
-                    SizedBox(width: 8.w),
-                    const Text('アルバムからメディアを追加する'),
-                  ],
-                ),
-              ),
-              SizedBox(height: 32.h),
-            ],
-          ),
+            ),
+            SizedBox(height: 32.h),
+          ],
         ),
       ),
     );

--- a/lib/debug/debug_media_page.dart
+++ b/lib/debug/debug_media_page.dart
@@ -17,9 +17,9 @@ class _DebugMediaPageState extends State<DebugMediaPage> {
   final List<XFile?> _files = [];
 
   final _picker = ImagePicker();
-  final int maxMediaCount = 4;
+  final int maxSelectedMediaCount = 4;
 
-  bool get _isFullMediaCount => _files.length >= maxMediaCount;
+  bool get _isFullSelectedMediaCount => _files.length >= maxSelectedMediaCount;
 
   void _setLoading(bool value) {
     setState(() {
@@ -35,9 +35,16 @@ class _DebugMediaPageState extends State<DebugMediaPage> {
       _setLoading(false);
       return;
     }
-    setState(() {
-      _files.addAll(files);
-    });
+    for (final file in files) {
+      if (_isFullSelectedMediaCount) {
+        _setLoading(false);
+        return;
+      } else {
+        setState(() {
+          _files.add(file);
+        });
+      }
+    }
     _setLoading(false);
   }
 
@@ -109,7 +116,7 @@ class _DebugMediaPageState extends State<DebugMediaPage> {
                     ),
               const Spacer(),
               ElevatedButton(
-                onPressed: _isFullMediaCount ? null : _onPressedCamera,
+                onPressed: _isFullSelectedMediaCount ? null : _onPressedCamera,
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   crossAxisAlignment: CrossAxisAlignment.center,
@@ -122,7 +129,7 @@ class _DebugMediaPageState extends State<DebugMediaPage> {
               ),
               SizedBox(height: 16.h),
               ElevatedButton(
-                onPressed: _isFullMediaCount ? null : _onPressedGallery,
+                onPressed: _isFullSelectedMediaCount ? null : _onPressedGallery,
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   crossAxisAlignment: CrossAxisAlignment.center,

--- a/lib/debug/debug_media_page.dart
+++ b/lib/debug/debug_media_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:pg_mobile/constants/app_colors.dart';
+import 'package:pg_mobile/extensions/target_platform_extension.dart';
 import 'package:pg_mobile/extensions/x_file_extension.dart';
 import 'package:pg_mobile/util/media_util.dart';
 import 'package:video_player/video_player.dart';
@@ -50,7 +51,8 @@ class _DebugMediaPageState extends State<DebugMediaPage> {
 
   Future<void> _onPressedGallery() async {
     final status = await Permission.photos.request();
-    if (!status.isGranted) {
+    if (!mounted) return;
+    if (Theme.of(context).platform.isIOS && !status.isGranted) {
       // TODO: アラートダイアログを表示
       await openAppSettings();
       return;
@@ -84,7 +86,8 @@ class _DebugMediaPageState extends State<DebugMediaPage> {
 
   Future<void> _onPressedCamera() async {
     final status = await Permission.camera.request();
-    if (!status.isGranted) {
+    if (!mounted) return;
+    if (Theme.of(context).platform.isIOS && !status.isGranted) {
       // TODO: アラートダイアログを表示
       await openAppSettings();
       return;

--- a/lib/debug/debug_media_page.dart
+++ b/lib/debug/debug_media_page.dart
@@ -19,6 +19,8 @@ class _DebugMediaPageState extends State<DebugMediaPage> {
   final _picker = ImagePicker();
   final int maxMediaCount = 4;
 
+  bool get _isFullMediaCount => _files.length >= maxMediaCount;
+
   void _setLoading(bool value) {
     setState(() {
       _isLoading = value;
@@ -27,7 +29,6 @@ class _DebugMediaPageState extends State<DebugMediaPage> {
 
   Future<void> _onPressedGallery() async {
     if (_isLoading) return;
-    if (_files.length >= maxMediaCount) return;
     _setLoading(true);
     final files = await _picker.pickMultipleMedia();
     if (files.isEmpty) {
@@ -42,7 +43,6 @@ class _DebugMediaPageState extends State<DebugMediaPage> {
 
   Future<void> _onPressedCamera() async {
     if (_isLoading) return;
-    if (_files.length >= maxMediaCount) return;
     _setLoading(true);
     final image = await _picker.pickImage(source: ImageSource.camera);
     if (image == null) {
@@ -53,6 +53,12 @@ class _DebugMediaPageState extends State<DebugMediaPage> {
       _files.add(image);
     });
     _setLoading(false);
+  }
+
+  void _removeMedia(int index) {
+    setState(() {
+      _files.removeAt(index);
+    });
   }
 
   @override
@@ -75,23 +81,35 @@ class _DebugMediaPageState extends State<DebugMediaPage> {
                         itemCount: _files.length,
                         scrollDirection: Axis.horizontal,
                         itemBuilder: (context, index) {
-                          return Container(
-                            width: 120.h,
-                            decoration: BoxDecoration(
-                              color: AppColors.gray2,
-                              image: DecorationImage(
-                                image: FileImage(
-                                  File(_files[index]!.path),
+                          return Stack(
+                            alignment: Alignment.topRight,
+                            children: [
+                              Container(
+                                width: 120.h,
+                                decoration: BoxDecoration(
+                                  color: AppColors.gray2,
+                                  image: DecorationImage(
+                                    image: FileImage(
+                                      File(_files[index]!.path),
+                                    ),
+                                  ),
                                 ),
                               ),
-                            ),
+                              IconButton(
+                                onPressed: () => _removeMedia(index),
+                                style: IconButton.styleFrom(
+                                  backgroundColor: AppColors.gray1A80,
+                                ),
+                                icon: const Icon(Icons.close),
+                              ),
+                            ],
                           );
                         },
                       ),
                     ),
               const Spacer(),
               ElevatedButton(
-                onPressed: _onPressedCamera,
+                onPressed: _isFullMediaCount ? null : _onPressedCamera,
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   crossAxisAlignment: CrossAxisAlignment.center,
@@ -104,7 +122,7 @@ class _DebugMediaPageState extends State<DebugMediaPage> {
               ),
               SizedBox(height: 16.h),
               ElevatedButton(
-                onPressed: _onPressedGallery,
+                onPressed: _isFullMediaCount ? null : _onPressedGallery,
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   crossAxisAlignment: CrossAxisAlignment.center,

--- a/lib/debug/debug_media_page.dart
+++ b/lib/debug/debug_media_page.dart
@@ -1,6 +1,9 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:pg_mobile/constants/app_colors.dart';
 
 class DebugMediaPage extends StatefulWidget {
   const DebugMediaPage({Key? key}) : super(key: key);
@@ -11,7 +14,7 @@ class DebugMediaPage extends StatefulWidget {
 
 class _DebugMediaPageState extends State<DebugMediaPage> {
   bool _isLoading = false;
-  List<XFile?> _files = [];
+  final List<XFile?> _files = [];
 
   final _picker = ImagePicker();
   final int maxMediaCount = 4;
@@ -32,7 +35,7 @@ class _DebugMediaPageState extends State<DebugMediaPage> {
       return;
     }
     setState(() {
-      _files = files;
+      _files.addAll(files);
     });
     _setLoading(false);
   }
@@ -64,7 +67,28 @@ class _DebugMediaPageState extends State<DebugMediaPage> {
           child: Column(
             children: [
               const Spacer(),
-              if (_files.isEmpty) const Text('画像・動画が選択されていません'),
+              _files.isEmpty
+                  ? const Text('画像・動画が選択されていません')
+                  : SizedBox(
+                      height: 120.h,
+                      child: ListView.builder(
+                        itemCount: _files.length,
+                        scrollDirection: Axis.horizontal,
+                        itemBuilder: (context, index) {
+                          return Container(
+                            width: 120.h,
+                            decoration: BoxDecoration(
+                              color: AppColors.gray2,
+                              image: DecorationImage(
+                                image: FileImage(
+                                  File(_files[index]!.path),
+                                ),
+                              ),
+                            ),
+                          );
+                        },
+                      ),
+                    ),
               const Spacer(),
               ElevatedButton(
                 onPressed: _onPressedCamera,

--- a/lib/debug/debug_media_page.dart
+++ b/lib/debug/debug_media_page.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:pg_mobile/constants/app_colors.dart';
 import 'package:pg_mobile/extensions/x_file_extension.dart';
 import 'package:video_player/video_player.dart';
@@ -57,13 +58,20 @@ class _DebugMediaPageState extends State<DebugMediaPage> {
   Future<void> _onPressedGallery() async {
     if (_isLoading) return;
     _setLoading(true);
-    final pickedFiles = await _picker.pickMultipleMedia();
+    final status = await Permission.photos.request();
+    if (!status.isGranted) {
+      // TODO: アラートダイアログを表示
+      await openAppSettings();
+      _setLoading(false);
+      return;
+    }
+    List<XFile?> pickedFiles = await _picker.pickMultipleMedia();
     if (pickedFiles.isEmpty) {
       _setLoading(false);
       return;
     }
     for (final file in pickedFiles) {
-      if (_disableAddMedia) {
+      if (file == null || _disableAddMedia) {
         continue;
       } else if (file.isVideo && _files.isEmpty) {
         setState(() {
@@ -83,6 +91,13 @@ class _DebugMediaPageState extends State<DebugMediaPage> {
   Future<void> _onPressedCamera() async {
     if (_isLoading) return;
     _setLoading(true);
+    final status = await Permission.camera.request();
+    if (!status.isGranted) {
+      // TODO: アラートダイアログを表示
+      await openAppSettings();
+      _setLoading(false);
+      return;
+    }
     final image = await _picker.pickImage(source: ImageSource.camera);
     if (image == null) {
       _setLoading(false);

--- a/lib/debug/debug_media_page.dart
+++ b/lib/debug/debug_media_page.dart
@@ -147,14 +147,10 @@ class _DebugMediaPageState extends State<DebugMediaPage> {
                                         image: FileImage(
                                           File(file.path),
                                         ),
+                                        fit: BoxFit.cover,
                                       )
                                     : file.isVideo
-                                        ? AspectRatio(
-                                            aspectRatio: 1.0,
-                                            child: VideoPlayer(
-                                              _videoController,
-                                            ),
-                                          )
+                                        ? VideoPlayer(_videoController)
                                         : const SizedBox.shrink(),
                               ),
                               IconButton(

--- a/lib/debug/debug_page.dart
+++ b/lib/debug/debug_page.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:pg_mobile/debug/debug_follow_list_page.dart';
 import 'package:pg_mobile/debug/debug_follower_list_page.dart';
+import 'package:pg_mobile/debug/debug_media_page.dart';
 import 'package:pg_mobile/debug/debug_pgn_page.dart';
 import 'package:pg_mobile/debug/debug_text_theme_page.dart';
 import 'package:pg_mobile/debug/login_sample/login_sample.dart';
 import 'package:pg_mobile/repository/mastodon_repository.dart';
+import 'package:pg_mobile/util.dart';
 
 class DebugPage extends StatefulWidget {
   const DebugPage({Key? key}) : super(key: key);
@@ -103,6 +105,13 @@ class _DebugPageState extends State<DebugPage> {
               });
             },
           ),
+          _button(
+            'メディア（画像・動画）画面',
+            onPressed: () {
+              Util.pushScreen(context, const DebugMediaPage());
+            },
+          ),
+          SizedBox(height: 64.h),
         ],
       ),
     );

--- a/lib/extensions/target_platform_extension.dart
+++ b/lib/extensions/target_platform_extension.dart
@@ -1,0 +1,6 @@
+import 'package:flutter/material.dart';
+
+extension TargetPlatformExtension on TargetPlatform {
+  bool get isIOS => this == TargetPlatform.iOS;
+  bool get isAndroid => this == TargetPlatform.android;
+}

--- a/lib/extensions/x_file_extension.dart
+++ b/lib/extensions/x_file_extension.dart
@@ -1,0 +1,11 @@
+import 'package:image_picker/image_picker.dart';
+import 'package:pg_mobile/models/media_type.dart';
+import 'package:pg_mobile/util/media_util.dart';
+
+extension XFileExtension on XFile {
+  MediaType get mediaType => MediaUtil.judgeMediaType(this);
+
+  bool get isImage => mediaType == MediaType.image;
+  bool get isVideo => mediaType == MediaType.video;
+  bool get isOther => !(isImage || isVideo);
+}

--- a/lib/extensions/x_file_extension.dart
+++ b/lib/extensions/x_file_extension.dart
@@ -5,7 +5,12 @@ import 'package:pg_mobile/util/media_util.dart';
 extension XFileExtension on XFile {
   MediaType get mediaType => MediaUtil.judgeMediaType(this);
 
+  /// ファイルの種類が画像かどうか判定します。
   bool get isImage => mediaType == MediaType.image;
+
+  /// ファイルの種類が動画かどうか判定します。
   bool get isVideo => mediaType == MediaType.video;
+
+  /// ファイルの種類が画像と動画以外かどうか判定します。
   bool get isOther => !(isImage || isVideo);
 }

--- a/lib/models/media_type.dart
+++ b/lib/models/media_type.dart
@@ -1,0 +1,1 @@
+enum MediaType { image, video, other }

--- a/lib/util/media_util.dart
+++ b/lib/util/media_util.dart
@@ -1,0 +1,25 @@
+import 'package:image_picker/image_picker.dart';
+import 'package:pg_mobile/models/media_type.dart';
+
+class MediaUtil {
+  MediaUtil._();
+
+  static MediaType judgeMediaType(XFile file) {
+    // ファイルのパスを取得
+    final path = file.path;
+    // ファイルの拡張子を取得
+    final fileExtension = path.split('.').last.toLowerCase();
+    // 一般的な画像ファイルの拡張子
+    final imageExtensions = ['jpg', 'jpeg', 'png', 'gif', 'bmp'];
+    // 一般的な動画ファイルの拡張子
+    final videoExtensions = ['mp4', 'mov', 'avi', 'mkv', 'wmv'];
+    // 拡張子を元にファイルの種類を判定
+    if (imageExtensions.contains(fileExtension)) {
+      return MediaType.image;
+    } else if (videoExtensions.contains(fileExtension)) {
+      return MediaType.video;
+    } else {
+      return MediaType.other;
+    }
+  }
+}

--- a/lib/util/media_util.dart
+++ b/lib/util/media_util.dart
@@ -1,9 +1,11 @@
 import 'package:image_picker/image_picker.dart';
 import 'package:pg_mobile/models/media_type.dart';
 
+/// 画像や動画などのメディアに関するユーティリティークラスです。
 class MediaUtil {
   MediaUtil._();
 
+  /// アルバムから複数の画像や動画を取得します。
   static Future<List<XFile?>> pickMultipleMediaFromGallery() async {
     final picker = ImagePicker();
     List<XFile?> files;
@@ -15,6 +17,7 @@ class MediaUtil {
     return files;
   }
 
+  /// カメラを起動して撮影した画像を取得します。
   static Future<XFile?> pickImageFromCamera() async {
     final picker = ImagePicker();
     XFile? file;
@@ -26,6 +29,7 @@ class MediaUtil {
     return file;
   }
 
+  /// ファイルの拡張子からメディアタイプを判定します。
   static MediaType judgeMediaType(XFile file) {
     // ファイルのパスを取得
     final path = file.path;

--- a/lib/util/media_util.dart
+++ b/lib/util/media_util.dart
@@ -4,6 +4,28 @@ import 'package:pg_mobile/models/media_type.dart';
 class MediaUtil {
   MediaUtil._();
 
+  static Future<List<XFile?>> pickMultipleMediaFromGallery() async {
+    final picker = ImagePicker();
+    List<XFile?> files;
+    try {
+      files = await picker.pickMultipleMedia();
+    } catch (e) {
+      throw Exception('Failed to pick multiple media from gallery: $e');
+    }
+    return files;
+  }
+
+  static Future<XFile?> pickImageFromCamera() async {
+    final picker = ImagePicker();
+    XFile? file;
+    try {
+      file = await picker.pickImage(source: ImageSource.camera);
+    } catch (e) {
+      throw Exception('Failed to pick image from camera: $e');
+    }
+    return file;
+  }
+
   static MediaType judgeMediaType(XFile file) {
     // ファイルのパスを取得
     final path = file.path;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   http: ^1.1.0
   intl: ^0.19.0
   image_picker: ^1.0.7
+  video_player: ^2.8.2
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,7 +49,7 @@ dependencies:
   intl: ^0.19.0
   image_picker: ^1.0.7
   video_player: ^2.8.2
-  permission_handler: ^11.0.1
+  permission_handler: ^11.3.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   intl: ^0.19.0
   image_picker: ^1.0.7
   video_player: ^2.8.2
+  permission_handler: ^11.0.1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   cloud_firestore: ^4.14.0
   http: ^1.1.0
   intl: ^0.19.0
+  image_picker: ^1.0.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 概要
メディア（画像と動画）の選択及びそのプレビュー表示について技術調査を行いました。

PGritの仕様に合わせ、以下のように実装を行いました。
- 画像は最大4点まで選択可能
- 動画は最大1点まで選択可能
- 画像と動画を組み合わせた選択は不可

## UI（本体アルバム）
<img src="https://github.com/shinonome-inc/pg_mobile/assets/82624334/b23fa265-3202-445a-aee3-3de379b28865" width="300">

## UI（プレビュー画面）
<img src="https://github.com/shinonome-inc/pg_mobile/assets/82624334/c93ee5cc-b830-4276-abae-e15dd75c7f12" width="300">

## 動作確認

https://github.com/shinonome-inc/pg_mobile/assets/82624334/c0f3044e-8b94-4e52-b1e1-d6f523c40b60

## 参考
- https://pub.dev/packages/image_picker
- https://pub.dev/packages/video_player
