### PR TITLE
FirebaseFireStoreのバージョンに関するエラーの修正

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -30,7 +30,7 @@ flutter_ios_podfile_setup
 target 'Runner' do
   use_frameworks!
   use_modular_headers!
-  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '10.20.0'
+  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '10.22.0'
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
   target 'RunnerTests' do
     inherit! :search_paths


### PR DESCRIPTION
## 概要
FirebaseFireStoreのバージョンに関するエラーを修正しました！

## エラー内容
```
[!] CocoaPods could not find compatible versions for pod "FirebaseCoreExtension":
  In snapshot (Podfile.lock):
    FirebaseCoreExtension (= 10.21.0, ~> 10.0)
  In Podfile:
    FirebaseFirestore (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, tag `10.20.0`) was resolved to 10.20.0, which depends on
      FirebaseFirestoreBinary (= 9.20.1) was resolved to 9.20.1, which depends on
        FirebaseCoreExtension (= 10.20.0)
Specs satisfying the `FirebaseCoreExtension (= 10.21.0, ~> 10.0), FirebaseCoreExtension (= 10.20.0)` dependency were found, but they required a higher minimum deployment target.
```
